### PR TITLE
general: T8595: add CLAUDE.md

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,1 +1,0 @@
-CLAUDE.md

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+../CLAUDE.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,5 @@ This repo is informal/optional and is not part of the canonical 14-repo build se
 Has a `VyOS-Networks/vyos-utils-misc` twin (also Perl, also tagged stale). Canonical side is here.
 
 ## Notes for future contributors
-- Don't confuse this repo with `vyos-utils` — completely different scope and language.
 - README is one paragraph; per-subdir `README` files are the real docs.
 - Stale by audit baseline; if you adopt one of these scripts into the product, fold it into `vyos-1x` rather than evolving it here.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,41 @@
+# CLAUDE.md
+
+## Project purpose
+A grab-bag of community-contributed VyOS helper scripts: admin tools, build tools, config processors, format converters. Not part of the shipped image — these are external scripts maintained loosely.
+
+## Tech stack
+- Mostly Perl (admin-tools: `dhcpremember.pl`, `ovpnbundle.pl`, `ravpnlist.pl`).
+- Other subdirectories carry shell / Python / format-conversion helpers.
+- No top-level build system; scripts run standalone.
+
+## Build / test / run
+- No build. Each subdirectory's script is self-contained — read each `README` for invocation.
+- No automated tests.
+
+## Repository layout
+- `admin-tools/` — Perl operator helpers (DHCP lease tracker, OpenVPN bundle generator, RA-VPN client lister).
+- `build-tools/` — image/build helpers.
+- `config-processors/` — config-tree post-processing.
+- `converters/` — format conversion.
+- `README` — top-level pitch ("contributions welcome").
+- `.github/workflows/` — minimal CI inherited via `vyos/.github` reusables.
+
+## Cross-repo context
+Distinct from `vyos/vyos-utils` (the OCaml validator suite baked into VyOS images). This repo is informal/optional and is not part of the canonical 14-repo build set in `VyOS-Networks/vyos-build-packages/repos.toml`. Stale by category-§3.10 in the relations doc.
+
+## Conventions
+- Commit / PR title: `component: T12345: description` (Phorge ID expected).
+- Default branch `master` (per audit baseline); pre-dates the `current` rename. Light governance — community-driven contributions.
+- No mandatory LICENSE in tree at root; treat each script's header as authoritative.
+
+## Mirror relationship
+Has a `VyOS-Networks/vyos-utils-misc` twin (also Perl, also tagged stale). Canonical side is here.
+
+## Notes for future contributors
+- Don't confuse this repo with `vyos-utils` — completely different scope and language.
+- README is one paragraph; per-subdir `README` files are the real docs.
+- Stale by audit baseline; if you adopt one of these scripts into the product, fold it into `vyos-1x` rather than evolving it here.
+
+---
+
+This file is mirrored on Confluence: [`vyos/vyos-utils-misc`](https://internal.confluence.vyos.com/wiki/spaces/VYOS/pages/818413866). The Confluence page also carries the per-repo audit data (settings, workflows, secret counts, hygiene) that complements this CLAUDE.md. Edit either side; resync via the documentation pipeline.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,3 @@ Has a `VyOS-Networks/vyos-utils-misc` twin (also Perl, also tagged stale). Canon
 - Don't confuse this repo with `vyos-utils` — completely different scope and language.
 - README is one paragraph; per-subdir `README` files are the real docs.
 - Stale by audit baseline; if you adopt one of these scripts into the product, fold it into `vyos-1x` rather than evolving it here.
-
----
-
-This file is mirrored on Confluence: [`vyos/vyos-utils-misc`](https://internal.confluence.vyos.com/wiki/spaces/VYOS/pages/818413866). The Confluence page also carries the per-repo audit data (settings, workflows, secret counts, hygiene) that complements this CLAUDE.md. Edit either side; resync via the documentation pipeline.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ A grab-bag of community-contributed VyOS helper scripts: admin tools, build tool
 - `.github/workflows/` — minimal CI inherited via `vyos/.github` reusables.
 
 ## Cross-repo context
-Distinct from `vyos/vyos-utils` (the OCaml validator suite baked into VyOS images). This repo is informal/optional and is not part of the canonical 14-repo build set in `VyOS-Networks/vyos-build-packages/repos.toml`. Stale by category-§3.10 in the relations doc.
+This repo is informal/optional and is not part of the canonical 14-repo build set in `VyOS-Networks/vyos-build-packages/repos.toml`. Stale by category-§3.10 in the relations doc.
 
 ## Conventions
 - Commit / PR title: `component: T12345: description` (Phorge ID expected).


### PR DESCRIPTION
## Summary

Adds a single source of truth for repo-level agent instructions, plus three symlinks so different agentic tools all read the same content from one canonical file.

**Files added:**

| Path | Type | Consumed by |
|---|---|---|
| `CLAUDE.md` | real file | Claude Code, Anthropic agents |
| `AGENTS.md` | symlink → `CLAUDE.md` | tools that follow the AGENTS.md convention (e.g. OpenAI Codex) |
| `.cursorrules` | symlink → `CLAUDE.md` | Cursor |
| `.github/copilot-instructions.md` | symlink → `../CLAUDE.md` | GitHub Copilot ([docs](https://docs.github.com/en/copilot/how-tos/configure-custom-instructions-in-your-ide/add-repository-instructions-in-your-ide)) |

**Rationale**

- One source of truth — guidance lives in `CLAUDE.md`, the symlinks are zero-content. No drift between four files.
- Each agentic tool reads its canonical filename and gets the same content.
- Mac/Linux dev environments handle symlinks natively. Windows checkouts may render them as text files containing the target path; the canonical `CLAUDE.md` is unaffected and still rendered/served correctly by GitHub.

**Out of scope**

Path-specific Copilot instructions (`.github/instructions/*.instructions.md`) need YAML frontmatter (`applyTo:`) and target specific globs, so they cannot be symlinks. Not added here; they can be authored as separate small files per-repo if/when narrow path-scoped guidance is needed.

Tracked under [T8595](https://vyos.dev/T8595).

## Test plan

- [ ] `CLAUDE.md` renders on GitHub.
- [ ] `AGENTS.md`, `.cursorrules`, `.github/copilot-instructions.md` resolve to CLAUDE.md content (`readlink` returns the right target).
- [ ] CI passes.

🤖 Generated by [robots](https://vyos.io)
