### PR TITLE
general: T8595: add AGENTS.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,1 +1,1 @@
-../CLAUDE.md
+../AGENTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ A grab-bag of community-contributed VyOS helper scripts: admin tools, build tool
 - `.github/workflows/` — minimal CI inherited via `vyos/.github` reusables.
 
 ## Cross-repo context
-This repo is informal/optional and is not part of the canonical 14-repo build set in `VyOS-Networks/vyos-build-packages/repos.toml`. Stale by category-§3.10 in the relations doc.
+This repo is informal/optional and is not part of the canonical 14-repo build set in `VyOS-Networks/vyos-build-packages/repos.toml`. Stale by category-§3.10 in the cross-repo audit.
 
 ## Conventions
 - Commit / PR title: `component: T12345: description` (Phorge ID expected).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,15 +21,12 @@ A grab-bag of community-contributed VyOS helper scripts: admin tools, build tool
 - `.github/workflows/` — minimal CI inherited via `vyos/.github` reusables.
 
 ## Cross-repo context
-This repo is informal/optional and is not part of the canonical 14-repo build set in `VyOS-Networks/vyos-build-packages/repos.toml`. Stale by category-§3.10 in the cross-repo audit.
+This repo is informal/optional and is not part of the canonical 14-repo build set in an internal repository. Stale by category-§3.10 in the cross-repo audit.
 
 ## Conventions
 - Commit / PR title: `component: T12345: description` (Phorge ID expected).
 - Default branch `master` (per audit baseline); pre-dates the `current` rename. Light governance — community-driven contributions.
 - No mandatory LICENSE in tree at root; treat each script's header as authoritative.
-
-## Mirror relationship
-Has a `VyOS-Networks/vyos-utils-misc` twin (also Perl, also tagged stale). Canonical side is here.
 
 ## Notes for future contributors
 - README is one paragraph; per-subdir `README` files are the real docs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,36 @@
-CLAUDE.md
+# AGENTS.md
+
+## Project purpose
+A grab-bag of community-contributed VyOS helper scripts: admin tools, build tools, config processors, format converters. Not part of the shipped image — these are external scripts maintained loosely.
+
+## Tech stack
+- Mostly Perl (admin-tools: `dhcpremember.pl`, `ovpnbundle.pl`, `ravpnlist.pl`).
+- Other subdirectories carry shell / Python / format-conversion helpers.
+- No top-level build system; scripts run standalone.
+
+## Build / test / run
+- No build. Each subdirectory's script is self-contained — read each `README` for invocation.
+- No automated tests.
+
+## Repository layout
+- `admin-tools/` — Perl operator helpers (DHCP lease tracker, OpenVPN bundle generator, RA-VPN client lister).
+- `build-tools/` — image/build helpers.
+- `config-processors/` — config-tree post-processing.
+- `converters/` — format conversion.
+- `README` — top-level pitch ("contributions welcome").
+- `.github/workflows/` — minimal CI inherited via `vyos/.github` reusables.
+
+## Cross-repo context
+This repo is informal/optional and is not part of the canonical 14-repo build set in `VyOS-Networks/vyos-build-packages/repos.toml`. Stale by category-§3.10 in the relations doc.
+
+## Conventions
+- Commit / PR title: `component: T12345: description` (Phorge ID expected).
+- Default branch `master` (per audit baseline); pre-dates the `current` rename. Light governance — community-driven contributions.
+- No mandatory LICENSE in tree at root; treat each script's header as authoritative.
+
+## Mirror relationship
+Has a `VyOS-Networks/vyos-utils-misc` twin (also Perl, also tagged stale). Canonical side is here.
+
+## Notes for future contributors
+- README is one paragraph; per-subdir `README` files are the real docs.
+- Stale by audit baseline; if you adopt one of these scripts into the product, fold it into `vyos-1x` rather than evolving it here.


### PR DESCRIPTION
Adds `AGENTS.md` (tool-neutral primary instructions) at repo root and a symlink `.github/copilot-instructions.md` → `../AGENTS.md` for Copilot code review compatibility.

Schema rationale and full spec: [T8595](https://vyos.dev/T8595).

**Why this shape:** Cursor 0.50+, Claude Code, OpenAI Codex, and Copilot Coding Agent / Chat / CLI read `AGENTS.md` natively. Copilot **code review** is the single tool that doesn't (per [GitHub's docs](https://docs.github.com/en/copilot/reference/custom-instructions-support)) — the symlink is the workaround until [community/discussions/174058](https://github.com/orgs/community/discussions/174058) lands. Replaces the previous `CLAUDE.md`-only schema PR for this repo.
