### PR TITLE
coderabbit: T8851: add .coderabbit.yaml for central-config inheritance

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+#
+# Per-repo CodeRabbit override for vyos/vyos-utils-misc.
+#
+# Most behavior is inherited from the org-level central baseline at
+# https://github.com/vyos/coderabbit/blob/production/.coderabbit.yaml
+# (loaded automatically because the central repo is named `coderabbit`
+# under the same GitHub org as this repo).
+#
+# When this repo has a VyOS-Networks mirror, this file is propagated by
+# the gen-1 mirror pipeline. CodeRabbit's Atlassian/Jira OAuth grant is
+# attached to the VyOS-Networks org only (one GitHub-org → Jira-tenant
+# link per install), so `usage: auto` self-disables on the public source
+# and activates on the private mirror — one file, both orgs.
+
+# Opt this repo into the inheritance chain. Without this, the file below
+# would entirely REPLACE the central baseline rather than merge per-field
+# on top of it — inheritance is disabled by default per CodeRabbit's
+# schema (https://docs.coderabbit.ai/configuration/configuration-inheritance).
+inheritance: true
+
+knowledge_base:
+  jira:
+    # `auto` is the cross-org-safe value: enabled on private/internal
+    # mirror repos where Jira OAuth is connected, disabled on the public
+    # source where it is not.
+    usage: auto
+    project_keys:
+      - VD


### PR DESCRIPTION
Adds a minimal `.coderabbit.yaml` so this repo joins the CodeRabbit central-configuration inheritance chain (per [T8851](https://vyos.dev/T8851) / [IS-430](https://vyos.atlassian.net/browse/IS-430)).

The file inherits the org-level baseline at [vyos/coderabbit](https://github.com/vyos/coderabbit/blob/production/.coderabbit.yaml) (loaded automatically because the central repo is named `coderabbit` under the same GitHub org) and only sets:

- `inheritance: true` — required, otherwise the per-repo file would silently **replace** the central baseline instead of merging per-field on top of it.
- `knowledge_base.jira` block — scopes CodeRabbit's Jira-context lookups to a specific project on the VyOS-Networks side. `usage: auto` self-disables on the public vyos source (no OAuth grant), activates on the private VyOS-Networks mirror (where the grant is attached). One file, both orgs.

## Phase 0 status

Phase 0 local `coderabbit review --base origin/<branch> --agent` was run once on the canary `vyos/.github` worktree (operator-approved batch waiver — see [T8851](https://vyos.dev/T8851)). The new file produced zero findings. The remaining PRs in this batch are byte-identical except for `project_keys`, so per-repo Phase 0 is waived for this fleet sweep.

## Sibling tracking

- Phorge master: [T8764](https://vyos.dev/T8764)
- Fleet rollout subtask: [T8851](https://vyos.dev/T8851)
- Change ticket: [IS-430](https://vyos.atlassian.net/browse/IS-430)

🤖 Generated by [robots](https://vyos.io)


[IS-430]: https://vyos.atlassian.net/browse/IS-430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IS-430]: https://vyos.atlassian.net/browse/IS-430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ