### PR TITLE
docs: AGENTS.md: reflect rollout 1c default-branch rename (current->rolling)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ This repo is informal/optional and is not part of the canonical 14-repo build se
 
 ## Conventions
 - Commit / PR title: `component: T12345: description` (Phorge ID expected).
-- Default branch `master` (per audit baseline); pre-dates the `current` rename. Light governance — community-driven contributions.
+- Default branch `rolling`. Light governance — community-driven contributions.
 - No mandatory LICENSE in tree at root; treat each script's header as authoritative.
 
 ## Notes for future contributors


### PR DESCRIPTION
Updates `AGENTS.md` to reflect the rollout 1c default-branch rename (release-train repos `current`->`rolling`; `vyos/.github` + non-release-train `current`->`production`) and the corresponding `@current`->`@production` reusable-workflow refs.

Tracking: Phorge [T8943](https://vyos.dev/T8943).

Doc-only change to `AGENTS.md`. No code or workflow behavior changes.

🤖 Generated by [robots](https://vyos.io)